### PR TITLE
fix bug if multiple lines contain word "server"

### DIFF
--- a/sbin/foreman-prepare-realm
+++ b/sbin/foreman-prepare-realm
@@ -22,7 +22,7 @@ die()   { echo "$@" 1>&2; exit 1; }
 [ ! -z $1 ] || usage
 [ ! -z $2 ] || usage
 
-SERVER=$(grep server /etc/ipa/default.conf | cut -f2 -d"=")
+SERVER=$(grep 'server =' /etc/ipa/default.conf | cut -f2 -d"=")
 
 if ipa --version 2>&1 | grep -q 'VERSION'
 then

--- a/sbin/foreman-prepare-realm
+++ b/sbin/foreman-prepare-realm
@@ -22,7 +22,7 @@ die()   { echo "$@" 1>&2; exit 1; }
 [ ! -z $1 ] || usage
 [ ! -z $2 ] || usage
 
-SERVER=$(grep 'server =' /etc/ipa/default.conf | cut -f2 -d"=")
+SERVER=$(grep '^server\s*=' /etc/ipa/default.conf | cut -f2 -d"=")
 
 if ipa --version 2>&1 | grep -q 'VERSION'
 then


### PR DESCRIPTION
error happend whith this patch https://github.com/Katello/forklift/pull/263
because in cat /etc/ipa/default.conf

```
#File modified by ipa-client-install

[global]
basedn = dc=example,dc=com
realm = EXAMPLE.COM
domain = example.com
server = centos7-freeipa-server.example.com
host = centos7-katello-nightly.example.com
xmlrpc_uri = https://centos7-freeipa-server.example.com/ipa/xml
enable_ra = True
```

and returned 2 string by 

```
grep server /etc/ipa/default.conf | cut -f2 -d"="
 centos7-freeipa-server.example.com
 https://centos7-freeipa-server.example.com/ipa/xml
```
